### PR TITLE
Quick fixes

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -310,8 +310,9 @@ var _Lobsters = Class.extend({
       if (data) {
         if (data.title)
           title_field.val(data.title.substr(0, title_field.maxLength));
-        if (data.url)
-          url_field.val(data.url);
+        // Don't change original URL, fixes bug 00009
+        //if (data.url)
+        //  url_field.val(data.url);
       }
 
       button.val(old_value);

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,7 @@ class User < ActiveRecord::Base
     s.boolean :email_messages, :default => false
     s.boolean :pushover_messages, :default => false
     s.boolean :email_mentions, :default => false
-    s.boolean :show_avatars, :default => true
+    s.boolean :show_avatars, :default => false
     s.boolean :show_story_previews, :default => false
     s.boolean :show_submitted_story_threads, :default => false
     s.string :totp_secret

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -55,7 +55,7 @@ class="comment <%= comment.current_vote ? (comment.current_vote[:vote] == 1 ?
         <span class="merge"></span>
       <% end %>
 
-      <% if (@user && @user.show_avatars?) || !@user %>
+      <% if (@user && @user.show_avatars?) %>
         <a href="/u/<%= comment.user.username %>"><%=
           avatar_img(comment.user, 16) %></a>
       <% end %>

--- a/app/views/stories/_listdetail.html.erb
+++ b/app/views/stories/_listdetail.html.erb
@@ -64,7 +64,7 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
               break_long_words(ms.domain) %></a>
           <% end %>
           <span class="byline">
-            <% if (@user && @user.show_avatars?) || !@user %>
+            <% if (@user && @user.show_avatars?) %>
               <a href="/u/<%= ms.user.username %>"><%=
                 avatar_img(ms.user, 16) %></a>
             <% end %>
@@ -96,7 +96,7 @@ class="story <%= story.vote && story.vote[:vote] == 1 ? "upvoted" : "" %>
     <% end %>
 
     <div class="byline">
-      <% if (@user && @user.show_avatars?) || !@user %>
+      <% if (@user && @user.show_avatars?) %>
         <a href="/u/<%= story.user.username %>"><%=
           avatar_img(story.user, 16) %></a>
       <% end %>


### PR DESCRIPTION
Keep the original URL when the "find title" button is pressed.
Hide avatars by default.