### PR TITLE
Track right clicks as well as left clicks

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -363,7 +363,7 @@ $(document).ready(function() {
     return false;
   });
 
-  $("span.link a[data-shortid]").click(function() {
+  $("span.link a[data-shortid]").mousedown(function() {
     var shortid = $(this).attr("data-shortid");
     Lobsters.clickStory(shortid);
   });


### PR DESCRIPTION
Right clicking on a link will now count towards that link's click count. This is so "open in new tab" will register as a clickthrough.